### PR TITLE
Show window when authorization missing

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -89,14 +89,9 @@ namespace OriApps.ResumeBoost
                     ShowMainWindow();
                 }
 
-                if (webView.CoreWebView2.Source.Contains("login"))
-                {
-                    statusLabel.Text = "Status: Waiting for user authorization...";
-                }
-                else
-                {
-                    statusLabel.Text = "Status: Still waiting for authorization...";
-                }
+                statusLabel.Text = webView.CoreWebView2.Source.Contains("login") 
+                    ? "Status: Waiting for user authorization..." 
+                    : "Status: Still waiting for authorization...";
             }
         }
 

--- a/Form1.cs
+++ b/Form1.cs
@@ -48,17 +48,22 @@ namespace OriApps.ResumeBoost
             }
         }
 
+        private void ShowMainWindow()
+        {
+            Show();
+            WindowState = FormWindowState.Normal;
+            notifyIcon.Visible = false;
+            ShowInTaskbar = true;
+        }
+
         private void notifyIcon_Click(object sender, EventArgs e)
         {
             if (e is MouseEventArgs args && args.Button != MouseButtons.Left)
             {
                 return;
             }
-            
-            Show();
-            WindowState = FormWindowState.Normal;
-            notifyIcon.Visible = false;
-            ShowInTaskbar = true;
+
+            ShowMainWindow();
         }
 
         private async void MainForm_Load(object sender, EventArgs e)
@@ -77,13 +82,21 @@ namespace OriApps.ResumeBoost
                 timerStart.Stop();
                 StartResumeBoostProcess();
             }
-            else if (webView.CoreWebView2.Source.Contains("login"))
-            {
-                statusLabel.Text = "Status: Waiting for user authorization...";
-            }
             else
             {
-                statusLabel.Text = "Status: Still waiting for authorization...";
+                if (WindowState == FormWindowState.Minimized)
+                {
+                    ShowMainWindow();
+                }
+
+                if (webView.CoreWebView2.Source.Contains("login"))
+                {
+                    statusLabel.Text = "Status: Waiting for user authorization...";
+                }
+                else
+                {
+                    statusLabel.Text = "Status: Still waiting for authorization...";
+                }
             }
         }
 
@@ -96,6 +109,11 @@ namespace OriApps.ResumeBoost
                     {
                         statusLabel.Text = "Status: Authorization verified.";
                         _state = ResumeBoostState.CheckingResumes;
+                    }
+                    else
+                    {
+                        ShowMainWindow();
+                        statusLabel.Text = "Status: Authorization required.";
                     }
                     break;
 


### PR DESCRIPTION
## Summary
- add helper method to bring main window to foreground
- surface authorization requirement when user not logged in

## Testing
- `dotnet build -p:EnableWindowsTargeting=true` *(fails: MSBUILD : error MSB4017: The build stopped unexpectedly because of an unexpected logger failure)*

------
https://chatgpt.com/codex/tasks/task_e_688e34cdfc7c832d809e0077dce7e6b3