### PR TITLE
Add single-instance enforcement via mutex

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -9,6 +9,9 @@ namespace OriApps.ResumeBoost
 
         private string _lastBoostTime = "";
 
+        private const int WM_USER = 0x0400;
+        internal const int WM_SHOWMAIN = WM_USER + 1;
+
         private const string Domain = "https://hh.ru/";
 
         public MainForm()
@@ -54,6 +57,15 @@ namespace OriApps.ResumeBoost
             WindowState = FormWindowState.Normal;
             notifyIcon.Visible = false;
             ShowInTaskbar = true;
+        }
+
+        protected override void WndProc(ref Message m)
+        {
+            if (m.Msg == WM_SHOWMAIN)
+            {
+                ShowMainWindow();
+            }
+            base.WndProc(ref m);
         }
 
         private void notifyIcon_Click(object sender, EventArgs e)

--- a/Form1.cs
+++ b/Form1.cs
@@ -64,7 +64,10 @@ namespace OriApps.ResumeBoost
             if (m.Msg == WM_SHOWMAIN)
             {
                 ShowMainWindow();
+                
+                Activate();
             }
+            
             base.WndProc(ref m);
         }
 

--- a/Form1.cs
+++ b/Form1.cs
@@ -57,6 +57,9 @@ namespace OriApps.ResumeBoost
             WindowState = FormWindowState.Normal;
             notifyIcon.Visible = false;
             ShowInTaskbar = true;
+
+            TopMost = true;
+            TopMost = false;
         }
 
         protected override void WndProc(ref Message m)

--- a/Program.cs
+++ b/Program.cs
@@ -1,13 +1,34 @@
+using System.Runtime.InteropServices;
+using System.Threading;
+
 namespace OriApps.ResumeBoost;
 
 static class Program
 {
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern IntPtr FindWindow(string? lpClassName, string? lpWindowName);
+
+    [DllImport("user32.dll")]
+    private static extern bool PostMessage(IntPtr hWnd, int Msg, IntPtr wParam, IntPtr lParam);
+
     /// <summary>
     ///  The main entry point for the application.
     /// </summary>
     [STAThread]
     static void Main()
     {
+        using Mutex mutex = new Mutex(true, "OriApps.ResumeBoost.Mutex", out bool createdNew);
+        if (!createdNew)
+        {
+            IntPtr hWnd = FindWindow(null, "Resume Boost");
+            if (hWnd != IntPtr.Zero)
+            {
+                PostMessage(hWnd, MainForm.WM_SHOWMAIN, IntPtr.Zero, IntPtr.Zero);
+            }
+            return;
+        }
+
         // To customize application configuration such as set high DPI settings or default font,
         // see https://aka.ms/applicationconfiguration.
         ApplicationConfiguration.Initialize();

--- a/Program.cs
+++ b/Program.cs
@@ -4,12 +4,14 @@ namespace OriApps.ResumeBoost;
 
 static class Program
 {
-    [DllImport("user32.dll", SetLastError = true)]
+    [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
     private static extern IntPtr FindWindow(string? lpClassName, string? lpWindowName);
 
     [DllImport("user32.dll")]
     private static extern bool PostMessage(IntPtr hWnd, int Msg, IntPtr wParam, IntPtr lParam);
-
+    
+    private static Mutex? _mutex;
+    
     /// <summary>
     ///  The main entry point for the application.
     /// </summary>
@@ -29,20 +31,16 @@ static class Program
 
     private static bool TryPreventSecondInstance()
     {
-        using var mutex = new Mutex(true, "OriApps.ResumeBoost.Mutex", out bool createdNew);
+        _mutex = new Mutex(true, "OriApps.ResumeBoost.Mutex", out bool createdNew);
 
         if (!createdNew)
         {
-            // Find the existing window by its title
             IntPtr hWnd = FindWindow(null, "Resume Boost");
-    
             if (hWnd != IntPtr.Zero)
             {
-                // Send a custom message to bring the existing window to the foreground
                 PostMessage(hWnd, MainForm.WM_SHOWMAIN, IntPtr.Zero, IntPtr.Zero);
             }
-    
-            // Exit the current application instance
+            
             return true;
         }
 


### PR DESCRIPTION
## Summary
- ensure only one instance runs by creating a named mutex
- show existing window when a second launch occurs using a WM_SHOWMAIN message
- expose WM_SHOWMAIN constant in MainForm and reuse it in Program to avoid duplication
- look up the existing window by its caption ("Resume Boost") instead of class name

## Testing
- `dotnet build -p:EnableWindowsTargeting=true`


------
https://chatgpt.com/codex/tasks/task_e_688e450e76c4832da9075d0c40bc0aaa